### PR TITLE
Ontology update

### DIFF
--- a/annotation_guidelines.md
+++ b/annotation_guidelines.md
@@ -203,10 +203,17 @@ Examples of STAFF, with the span bolded:
 Examples of HOSPITAL, with the span bolded:
 
 - Seen by Dr. Gloria de la Vega, MD, **Children's Hospital of Philadelphia**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> ADHD Management Center
+- **CHOP**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> Pediatrics
+- Pt got treatment at **Cincinnati**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> before coming here, see transfer notes.
 
+(Context matters -- in this example "Cincinnati" refers to the hospital "Cincinnati Children's Hospital", not the city. 
+In a note saying "Pt lives in Cincinnati", it would instead be labeled as CITY.)
+
+A DEPARTMENT is any sub-unit within a hospital, including programs, services, and centers. 
 Examples of DEPARTMENT, with the span bolded:
 
 - Seen by Dr. Gloria de la Vega, MD, Children's Hospital of Philadelphia **ADHD Management Center**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->
+- CHOP **Pediatrics**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->
 
 Generic departments -- in other words, departments that you might expect to exist with that same name at most hospitals, like ER, Cardiology, NICU -- should still be labeled, but also be marked as "[NonIdentifying](#nonindentifying)". 
 For example, in the note "Pt came to **ER**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> for persistent fever (4 days), admitted to **PICU**<!-- style="background-color: rgba(var(--color-highlight), .2)"-->" both "ER" and "PICU" would have "NonIdentifying" checked as well, since those are generic names. 
@@ -356,7 +363,6 @@ Examples of OTHER MISC, with the span bolded:
 - Pt complains of BL wrist stiffness and pain. She is an **Olympic swimmer (won two gold and two silver medals in the 2016 games!)**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->. Work closely with both patient and coach to develop a treatment plan that takes her training into account. 
 - His aunt is the **first recipient of the Nobel Peace Prize**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> in this decade.
 
-
 ### TELEPHONE NUMBERS
 
 Annotate every instance of a telephone number. 
@@ -492,16 +498,8 @@ For example, the note "Recommended catch up schedule (**www.cdc.gov/vaccines/sch
 It doesn't provide information about who the patient is (or their relatives, employer, or household members) or any information about where they received care. 
 
 The note "**AAP**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> recommends ASD screening for children with no productive language at **18m**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->" would have two spans that should be checked "NonIdentifying": 
-"AAP" should get the label NAMES (it's an organization, the American Academy of Pediatrics), and "18m" should get AGES, and both would be checked "NonIdentifying". 
+"AAP" (the American Academy of Pediatrics) should get the label ORGANIZATION, and "18m" should get AGES, and both would be checked "NonIdentifying". 
 (Note that "ASD" is an abbreviation for Autism Spectrum Disorder and should not be annotated.)
-
-<div class = "important">
-<b style="color: rgb(var(--color-highlight));">Important note</b><br>
-
-The "NonIdentifying" option is only available at the coarse coding levels (for example, NAMES, but not PATIENT or STAFF).
-Do not bother to code nonidentifying spans with the more fine-grained label options; just use the coarse categories and check "NonIdentifying".
-
-</div>
 
 ### Unsure
 
@@ -514,14 +512,6 @@ This will flag it in the data, and it can be included in regular review and disc
 
 Don't over-use the Unsure option -- if you find you frequently feel like you are unsure of your annotations, that suggests there's a problem with the ontology, the coding training, or both. 
 Please bring that to the attention of the rest of the research team, and thank you for contributing to the improvement of the coding process! 
-
-<div class = "important">
-<b style="color: rgb(var(--color-highlight));">Important note</b><br>
-
-The "Unsure" option is only available at the coarse coding levels (for example, NAMES, but not PATIENT or STAFF).
-Do not bother to code unsure spans with the more fine-grained label options; just use the coarse category that's your best guess and check "Unsure".
-
-</div>
 
 ## References
 

--- a/annotation_guidelines.md
+++ b/annotation_guidelines.md
@@ -291,6 +291,13 @@ Annotate every instance of age.
 Note that HIPAA does not consider age to be PII unless it is 90 or greater, but we're still labeling every instance of age.
 When HIPAA-protected ages occur (anything 90 or greater), then instead of using the label AGES, use AGE-90PLUS.
 
+<div class = "behind-the-scenes">
+<b style="color: rgb(var(--color-highlight));">Ages under 90</b><br>
+
+Even though we're not explicitly marking ages under 90 as "[NonIdentifying](#nonindentifying)", we have the option to do that systematically after the fact.
+
+</div>
+
 When age is listed with units (like year/month/week/day), the span should include the number and units, but not the word "old". 
 For ranges (for example, "15-18mos"), the span is the whole range, including both numbers and the hyphen (and units, if applicable).
 Examples of age, with the span bolded: 

--- a/annotation_guidelines.md
+++ b/annotation_guidelines.md
@@ -103,6 +103,7 @@ Some of the most frequent abbreviations are:
 - Sx = symptoms
 - Rx = treatment or prescription 
 - HPI = history of present illness
+- OSH = outside of the hospital (as in, patient received care for this condition OSH)
 - and [many more](https://medlineplus.gov/appendixb.html)!
 
 You'll also notice surprising or confusing formatting in notes, often the result of forms or templates. 
@@ -206,11 +207,12 @@ Examples of HOSPITAL, with the span bolded:
 Examples of DEPARTMENT, with the span bolded:
 
 - Seen by Dr. Gloria de la Vega, MD, Children's Hospital of Philadelphia **ADHD Management Center**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->
-- Pt came to **ER**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> for persistent fever (4 days), admitted to **PICU**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->
-- Sample sent to **dermatology**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->
+
+Generic departments -- in other words, departments that you might expect to exist with that same name at most hospitals, like ER, Cardiology, NICU -- should still be labeled, but also be marked as "[NonIdentifying](#nonindentifying)". 
+For example, in the note "Pt came to **ER**<!-- style="background-color: rgba(var(--color-highlight), .2)" --> for persistent fever (4 days), admitted to **PICU**<!-- style="background-color: rgba(var(--color-highlight), .2)"-->" both "ER" and "PICU" would have "NonIdentifying" checked as well, since those are generic names. 
 
 Note that sometimes the same phrase might refer to a department or not depending on context. 
-For example, "she was seen in **dermatology**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->" should be labeled DEPARTMENT, but "she had a number of dermatology tests" wouldn't be labeled because in that case it refers to the general medical field of dermatology, not the department at this hospital. 
+For example, "she was seen in **dermatology**<!-- style="background-color: rgba(var(--color-highlight), .2)" -->" should be labeled DEPARTMENT-Nonidentifying, but "she had a number of dermatology tests" wouldn't be labeled because in that case it refers to the general medical field of dermatology, not the department at this hospital. 
 
 The label ORGANIZATION is for entities other than hospitals or other healthcare facilities.
 The most common examples are employers or schools (of the patient, or relatives, or household members).

--- a/development_notes.md
+++ b/development_notes.md
@@ -1,0 +1,27 @@
+## Creating an ontology
+
+
+## Considerations for coder training
+
+
+# Creating these documents
+
+The coder training procedure document and annotation guidelines are markdown files intended for use with [LiaScript](https://liascript.github.io/). 
+LiaScript is an open source markdown parser designed for educational content. 
+If you want to learn more about how the Arcus Education team uses liascript, check out our [education module docs](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/docs.md#1), which includes details about metadata we include as well as things like [quiz questions](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/docs.md#quizzes-automatically-graded-questions) and [highlight boxes](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/docs.md#including-highlight-boxes).
+
+Note that LiaScript won't work for private repos, or repos on Enterprise GH, which is why these documents are hosted on github.com.
+
+Image files (including gifs) are stored in the media directory of this repository. 
+
+## Annotation guidelines
+
+The goal for this document is for it to serve as a useful reference to coders as they annotate. 
+The expectation is that a coder getting ready to work would pull up both their Arcus Lab and, in another tab, the annotation guidelines. 
+
+The heading structure in the Ontology section (a heading for each category in the ontology) is intentional -- it results in one page for each category in the rendered liascript site. 
+This makes navigating to a particular category easy via the table of contents on the left, and it also makes it possible to share a link to a specific category in the ontology (e.g. the [NAMES](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/note_deidentification/main/annotation_guidelines.md#names) category), which is useful for a group of coders communicating with each other. 
+
+Brat allows entities that can be checked as well as categories selected from the ontology -- this effectively allows for a second dimension of information in the coding. 
+In the current ontology, we created two of these [additional options](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/note_deidentification/main/annotation_guidelines.md#additional-options), "nonidentifying" and "unsure". 
+Other ontologies have made use of that kind of tool to denote referent (such as "patient," "family member," and "hospital staff," so that a coder can label a span as, for example, "phone number" and then select "patient" to indicate it's a patient phone number).


### PR DESCRIPTION
Updates to the annotation guidelines in response to feedback from SCIT-970 study team on their initial review, and from conversations within ADS: 

- "Generic" departments (ER, Radiology, NICU) should be marked "NonIndentifying". This is in line with the [i2b2 coding guidelines](https://github.com/obi-ml-public/ehr_deidentification/blob/main/AnnotationGuidelines.md#hosp), but in contrast to [scrubber](https://lhncbc.nlm.nih.gov/scrubber/annotation/pdf.papers/Guidelines.2016.06.28.pdf).
- The checkboxes for "Unsure" and "NonIndentifying" are now available to coders at L1 and L2 categories in the ontology, instead of only at L1.  

This PR also adds a new file, development_notes.md, which includes information about how these documents were created. 